### PR TITLE
Added clone method

### DIFF
--- a/src/lgtm/object_validator.js
+++ b/src/lgtm/object_validator.js
@@ -89,6 +89,23 @@ ObjectValidator.prototype = {
     }
   },
 
+  clone: function () {
+    var clone       = new ObjectValidator();
+    var validations = this._validations;
+    keys(validations).forEach(function (attr) {
+      clone._validations[attr] = validations[attr].map(
+        function (list) { return list.slice(); }
+      );
+    });
+    var dependencies = this._dependencies;
+    keys(dependencies).forEach(function (attr) {
+      clone._dependencies[attr] = dependencies[attr].map(
+        function (list) { return list.slice(); }
+      );
+    });
+    return clone;
+  },
+
   _validateAttribute: function(object, attr) {
     var value       = get(object, attr);
     var validations = this._validations[attr];

--- a/src/lgtm/validator_builder.js
+++ b/src/lgtm/validator_builder.js
@@ -99,6 +99,23 @@ ValidatorBuilder.prototype = {
 
   build: function() {
     return this._validator;
+  },
+
+  clone: function() {
+    var clone = new ValidatorBuilder();
+    if (this._attr != null) {
+      clone._attr = this._attr;
+    }
+    if (this._conditions != null) {
+      clone._conditions = this._conditions.slice();
+    }
+    if (this._conditionDependencies != null) {
+      clone._conditionDependencies = this._conditionDependencies.map(
+        function (dependencies) { return dependencies.slice(); }
+      );
+    }
+    clone._validator = this._validator.clone();
+    return clone;
   }
 };
 


### PR DESCRIPTION
I wanted the ability to compose validators to allow client side and server side-specific validation to be separated as necessary and combined in the relevant models, and also allow related models to share validations. A use case might be:

```javascript
// client/validator.js
// Performs basic validations to provide a decent UX
module.exports = require('lgtm').validator().validates('token').required().string();

// server/validator.js
// Performs all the validations the client does, but also validates database column uniqueness, etc.
module.exports = require('../client/validator').clone().validates('token').unique();
```

To this end, I added a `clone` method to the builder and validator classes that does a deep clone for the specific structure of each. I also think it would also be good to have a `merge` method that clones and merges the properties to make composition like this easier.

I wanted to PR this and get input before continuing. The code works in my testing, but I will put together appropriate unit tests if you like this direction.