### PR TITLE
Allow options to be passed in when validating

### DIFF
--- a/src/lgtm/validator_builder.js
+++ b/src/lgtm/validator_builder.js
@@ -66,19 +66,19 @@ ValidatorBuilder.prototype = {
       }
     }
 
-    function validation(value, attr, object) {
+    function validation(value, attr, object, options) {
       let properties = getProperties(object, dependencies);
-      return predicate.apply(null, properties.concat([attr, object]));
+      return predicate.apply(null, properties.concat([attr, object, options]));
     }
 
     let conditions = this._conditions.slice();
     let conditionDependencies = this._conditionDependencies.slice();
 
-    function validationWithConditions(value, attr, object) {
+    function validationWithConditions(value, attr, object, options) {
       return all(conditions.map(function(condition, i) {
         let dependencies = conditionDependencies[i];
         let properties = getProperties(object, dependencies);
-        return condition.apply(null, properties.concat([attr, object]));
+        return condition.apply(null, properties.concat([attr, object, options]));
       })).then(function(results) {
         for (let i = 0; i < results.length; i++) {
           // a condition resolved to a falsy value; return as valid
@@ -87,7 +87,7 @@ ValidatorBuilder.prototype = {
           }
         }
         // all conditions resolved to truthy values; continue with validation
-        return validation(value, attr, object);
+        return validation(value, attr, object, options);
       });
     }
 

--- a/test/object_validator_test.js
+++ b/test/object_validator_test.js
@@ -74,14 +74,26 @@ describe('ObjectValidator', function() {
     });
   });
 
-  it('passes the validation function the value, key, and object being validated', () => {
+  it('passes the validation function the value, key, object, and options being validated', () => {
+    let options = { transaction: {} };
+
     object.firstName = 'Han';
 
-    validator.addValidation('firstName', function(value, key, obj) {
-      strictEqual(arguments.length, 3, 'passes three arguments');
+    validator.addValidation('firstName', function(value, key, obj, opts) {
+      strictEqual(arguments.length, 4, 'passes four arguments');
       strictEqual(value, 'Han', '1st argument is value');
       strictEqual(key, 'firstName', '2nd argument is key');
       strictEqual(obj, object, '3rd argument is object');
+      strictEqual(opts, options, '4th argument is options');
+    });
+
+    return validator.validate(object, options);
+  });
+
+  it('passes the validation function empty options by default', () => {
+    validator.addValidation('firstName', function(value, key, obj, opts) {
+      strictEqual(arguments.length, 4, 'passes four arguments');
+      deepEqual(opts, {}, '4th argument is empty options');
     });
 
     return validator.validate(object);

--- a/test/validator_test.js
+++ b/test/validator_test.js
@@ -155,6 +155,46 @@ describe('validator', () => {
       });
     });
 
+    it('allows conditionally running validations based on options', () => {
+      let object = {
+        name: null
+      };
+
+      let v =
+        buildValidator()
+          .validates('name')
+            .when('name', function (value, attr, object, options) {
+                return !options.nameOptional;
+              })
+              .required("You must enter a name.")
+          .build();
+
+        return v.validate(object).then(result => {
+          deepEqual(
+            result,
+            {
+              valid:  false,
+              errors: {
+                name: ["You must enter a name."]
+              }
+            }
+          );
+
+          return v.validate(object, { nameOptional: true }).then(result => {
+            deepEqual(
+              result,
+              {
+                  valid: true,
+                  errors: {
+                      name: []
+                  }
+              },
+              'options conditions are respected'
+            );
+          });
+        });
+    });
+
     it('allows conditionals that return promises', () => {
       validator =
         buildValidator()


### PR DESCRIPTION
I've found it pretty useful to run conditional validation based on application state at the time of validation that lies outside of the object's attributes, or pass unrelated options to the validator, such as for running validation checks within database transactions. Checking existence of rows, uniqueness, etc. won't work if the validation is being done while saving a child object inside of the parent's transaction without the child's checks being done within the same transaction.

This PR provides an optional `options` argument that defaults to `{}`. I've included tests for it in `validate` calls, and in conditional validation with `when`. Since one of the `ObjectValidator` tests checks for a strict number of function arguments, it was necessary to alter an existing test to reflect the additional argument. I don't know if this would generally be considered a breaking change, but the rationale is that that always passing `{}` by default avoids the need to do NRE checks in userland validator functions everywhere.

Thoughts/questions/feedback?
