### PR TITLE
LGTM 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   ],
   "author": "Square, Inc.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=6"
+  },
   "devDependencies": {
     "@babel/core": "^7.1.0",
     "@babel/plugin-external-helpers": "^7.0.0",


### PR DESCRIPTION
### Breaking Changes

#### Dropping node v4 support

This isn't strictly necessary, and for now lgtm will keep working on node v4. However, this removes it as a testing target and the next version will make no guarantees about its compatibility with node v4. Most of the rationale for this comes from dependencies no longer working with node v4.

#### Removing the default behavior for using a `.get()` on validated objects

This Ember-ism should be removed.

#### Removing the default usage of RSVP Promises

This Ember-ism should be removed.